### PR TITLE
Use self.net.module regardless of CPU or GPU

### DIFF
--- a/cellpose_omni/core.py
+++ b/cellpose_omni/core.py
@@ -416,7 +416,7 @@ class UnetModel():
         else:  
             for j in range(len(self.pretrained_model)):
                 
-                if self.torch and self.gpu:
+                if self.torch:
                     net = self.net.module
                 else:
                     net = self.net


### PR DESCRIPTION
Previously, if self.torch was true, self.net was replaced with self.net.module only if self.gpu was true. However, it needs to replaced even if self.gpu is false, otherwise errors such as `'DataParallel' object has no attribute 'load_model'` occur.